### PR TITLE
add travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+[![Build Status](https://travis-ci.org/HouzuoGuo/saptune.svg?branch=master)](https://travis-ci.org/HouzuoGuo/saptune)
+
 # saptune
 The utility adjusts system parameters such as kernel parameters and resource limits
 to allow running various SAP solutions at satisfactory performance.


### PR DESCRIPTION
Adds the required files for displaying build/test status in the README front page.

Untested as travis does not allow for easy testing ahead of time.

To enable it @HouzuoGuo would need to go to Travis CI and enable building for his repo.
See https://github.com/dmacvicar/garita as an example how it looks like.